### PR TITLE
fix: Do not deploy connector builtin by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,9 @@ ENV IPFS_ADDRESSES_ANNOUNCE=/ip4/127.0.0.1/tcp/4001,/ip4/127.0.0.1/tcp/4001/ws
 ENV FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR=/ip4/127.0.0.1/tcp/5001
 ENV FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR=/ip4/127.0.0.1/tcp/5001
 
+# do not deploy connector by default
+ENV FLUENCE_DEPLOY_CONNECTOR=false
+
 # download fs-repo-migrations
 RUN wget -qO - "https://dist.ipfs.io/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-amd64.tar.gz" | tar -C /usr/local/bin --strip-components=1 -zxvf -
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -8,15 +8,29 @@ Registry implements service discovery.
 
 ## [aqua-ipfs](https://github.com/fluencelabs/aqua-ipfs)
 
-This is a native IPFS integration with [Aqua](https://fluence.dev/docs/aqua-book/introduction) language. It is used to orchestrate IPFS file transfer with Aqua scripts.
+This is a native IPFS integration with
+[Aqua](https://fluence.dev/docs/aqua-book/introduction) language. It is used to
+orchestrate IPFS file transfer with Aqua scripts.
 
-Image flavours [ipfs](flavours.md#ipfs) and [rich](flavours.md#rich) have an IPFS daemon running as a sidecar and `aqua-ipfs` configured to use this sidecar IPFS daemon. [minimal](flavours.md#minimal) connects to an IPFS daemon hosted by [Fluence Labs](https://fluence.network).
+Image flavours [ipfs](flavours.md#ipfs) and [rich](flavours.md#rich) have an
+IPFS daemon running as a sidecar and `aqua-ipfs` configured to use this sidecar
+IPFS daemon. [minimal](flavours.md#minimal) connects to an IPFS daemon hosted by
+[Fluence Labs](https://fluence.network).
 
-In case you want to use a separately running IPFS daemon, you need to inject two variables:
+In case you want to use a separately running IPFS daemon, you need to inject two
+variables:
 
-- `FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR` - advertised to clients (e.g., frontend apps) to use in uploading files (`ipfs.put`), managing pins (`ipfs.pin`) etc.
-- `FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR` - used by the `aqua-ipfs` builtin to   connect to IPFS node
+- `FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR` - advertised to clients (e.g.,
+  frontend apps) to use in uploading files (`ipfs.put`), managing pins
+  (`ipfs.pin`) etc.
+- `FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR` - used by the `aqua-ipfs` builtin
+  to connect to IPFS node
 
 ## [trust-graph](https://github.com/fluencelabs/trust-graph)
 
-It can be used to create a trusted network, to manage service permissions with TLS certificates and other security related things.
+It can be used to create a trusted network, to manage service permissions with
+TLS certificates and other security related things.
+
+## [connector](https://github.com/fluencelabs/decider)
+
+Used to pull contracts and deploy from blockchain.

--- a/docs/flavours.md
+++ b/docs/flavours.md
@@ -1,8 +1,12 @@
 # Rust Peer Distro Flavours
 
-Each flavour is represented by a docker image tag. See the [docker hub](https://hub.docker.com/r/fluencelabs/rust-peer) and the [releases](https://github.com/fluencelabs/rust-peer-distro/releases) page.
+Each flavour is represented by a docker image tag. See the
+[docker hub](https://hub.docker.com/r/fluencelabs/rust-peer) and the
+[releases](https://github.com/fluencelabs/rust-peer-distro/releases) page.
 
-Each flavour builds upon its previous flavour. In particular, `ipfs` has everything that `minimal` has, and `rich` has everything that `minimal` and `ipfs` have.
+Each flavour builds upon its previous flavour. In particular, `ipfs` has
+everything that `minimal` has, and `rich` has everything that `minimal` and
+`ipfs` have.
 
 | flavour | IPFS daemon | services                         | binaries                                   |
 | ------- | ----------- | -------------------------------- | ------------------------------------------ |
@@ -14,20 +18,25 @@ Tag `latest` points to the latest version of `ipfs` flavour.
 
 ## minimal
 
-It contains Rust peer itself and some [builtin services](builtins.md). It serves as a base image for all other image flavours and is intended for those who want to run an IPFS node separately.
+It contains Rust peer itself and some [builtin services](builtins.md). It serves
+as a base image for all other image flavours and is intended for those who want
+to run an IPFS node separately.
 
 `FLUENCE_ENV_AQUA_IPFS_*` variables must be defined and point to externally
-running IPFS daemon in order for `aqua-ipfs` to work. If not defined, **aqua-ipfs
-builtin will be removed**.
+running IPFS daemon in order for `aqua-ipfs` to work. If not defined,
+**aqua-ipfs builtin will be removed**.
 
 | variable                                       | default                           | description                                                                                                     |
 | ---------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR` | `/dns4/ipfs.fluence.dev/tcp/5001` | advertised to clients (eg frontend apps) to use in uploading files (`ipfs.put`), managing pins (`ipfs.pin`) etc |
 | `FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR`    | `/dns4/ipfs.fluence.dev/tcp/5001` | used by aqua-ipfs builtin to connect to IPFS node                                                               |
+| `FLUENCE_DEPLOY_CONNECTOR`                     | `false`                           | switch to deploy connector builtin                                                                              |
 
 ## ipfs
 
-This is a Rust peer packaged with an [IPFS node](https://docs.ipfs.io/how-to/command-line-quick-start/#take-your-node-online) running inside a container.
+This is a Rust peer packaged with an
+[IPFS node](https://docs.ipfs.io/how-to/command-line-quick-start/#take-your-node-online)
+running inside a container.
 
 | variable                                       | default                                              | description                                                                                                     |
 | ---------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
@@ -40,10 +49,13 @@ This is a Rust peer packaged with an [IPFS node](https://docs.ipfs.io/how-to/com
 | `IPFS_ADDRESSES_ANNOUNCE`                      | `/ip4/127.0.0.1/tcp/4001,/ip4/127.0.0.1/tcp/4001/ws` | IPFS p2p multiaddr of the IPFS swarm protocol                                                                   |
 | `FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR` | `/ip4/127.0.0.1/tcp/5001`                            | advertised to clients (eg frontend apps) to use in uploading files (`ipfs.put`), managing pins (`ipfs.pin`) etc |
 | `FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR`    | `/ip4/127.0.0.1/tcp/5001`                            | used by aqua-ipfs builtin to connect to IPFS node                                                               |
+| `FLUENCE_DEPLOY_CONNECTOR`                     | `false`                                              | switch to deploy connector builtin                                                                              |
 
 ## rich
 
-This is a Rust peer packaged with an IPFS node, [Ceramic](https://developers.ceramic.network/learn/welcome/) CLI and some other binaries like bitcoin-cli or
+This is a Rust peer packaged with an IPFS node,
+[Ceramic](https://developers.ceramic.network/learn/welcome/) CLI and some other
+binaries like bitcoin-cli or
 [geth](https://geth.ethereum.org/docs/interface/command-line-options).
 
 | variable                                       | default                                              | description                                                                                                     |
@@ -58,3 +70,4 @@ This is a Rust peer packaged with an IPFS node, [Ceramic](https://developers.cer
 | `IPFS_ADDRESSES_ANNOUNCE`                      | `/ip4/127.0.0.1/tcp/4001,/ip4/127.0.0.1/tcp/4001/ws` | IPFS announce multiaddr                                                                                         |
 | `FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR` | `/ip4/127.0.0.1/tcp/5001`                            | advertised to clients (eg frontend apps) to use in uploading files (`ipfs.put`), managing pins (`ipfs.pin`) etc |
 | `FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR`    | `/ip4/127.0.0.1/tcp/5001`                            | used by aqua-ipfs builtin to connect to IPFS node                                                               |
+| `FLUENCE_DEPLOY_CONNECTOR`                     | `false`                                              | switch to deploy connector builtin                                                                              |

--- a/s6/minimal/etc/cont-init.d/50-connector
+++ b/s6/minimal/etc/cont-init.d/50-connector
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+
+if [[ ${FLUENCE_DEPLOY_CONNECTOR} != true ]]; then
+  echo "removing connector builtin"
+  rm -rf /builtins/connector
+fi


### PR DESCRIPTION
Until connector/decider is configurable lets not deploy it by default.